### PR TITLE
Replace chrono with std::time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,3 @@ homepage = "https://github.com/Yoric/timer.rs"
 readme = "README.md"
 keywords = ["timer", "alarm", "schedule", "chrono", "chronometer"]
 license = "MPL-2.0"
-
-
-[dependencies]
-chrono = "^0.4"
-


### PR DESCRIPTION
I made this change for a personal project but though I'd make a PR in case it is wanted.

Chrono provides many advanced timezone and date handling features but none of these are used by timer.rs and it pulls in a large number of dependencies.

For users currently using chrono there are `From` and `Into` implementations to convert between `chrono::DateTime` and `std::time::SystemTime`.