### PR TITLE
trait objects without an explicit `dyn` are deprecated

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ trait Executor<T> {
 /// thread.
 struct CallbackExecutor;
 
-impl Executor<Box<FnMut() + Send>> for CallbackExecutor {
+impl Executor<Box<dyn FnMut() + Send>> for CallbackExecutor {
     fn execute(&mut self, mut data : Box<FnMut() + Send>) {
         data();
     }


### PR DESCRIPTION
There are more of these in the code. I am sending the fix for one just to check if this is accepted.