### PR TITLE
Fixes CVE-2020-26235

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ license = "MPL-2.0"
 
 
 [dependencies]
-chrono = { version = "0.4.22", default-features = false, features = ["clock"] }
+chrono = { version = "0.4.22", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ license = "MPL-2.0"
 
 
 [dependencies]
-chrono = { version = "0.4.22", default-features = false }
+chrono = { version = "^0.4", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,4 @@ license = "MPL-2.0"
 
 
 [dependencies]
-chrono = "^0.4"
-
+chrono = { version = "0.4.22", default-features = false, features = ["clock"] }


### PR DESCRIPTION
This change should permit `cargo audit` to no longer flag `timer.rs` for CVE-2020-26235.  

This is required to fix: https://github.com/kimono-koans/httm/issues/54